### PR TITLE
nh os repl: init

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -93,7 +93,7 @@ pub struct CommonReplArgs {
 #[clap(verbatim_doc_comment)]
 /// NixOS functionality
 ///
-/// Implements mostly around but not exclusively nixos-rebuild
+/// Implements functionality mostly around but not exclusive to nixos-rebuild
 pub struct OsArgs {
     #[command(subcommand)]
     pub action: OsCommandType,
@@ -113,7 +113,9 @@ pub enum OsCommandType {
     /// Build the new configuration
     Build(OsSubcommandArgs),
 
-    /// Enter a Nix REPL with the target
+    /// Enter a Nix REPL with the target installable
+    ///
+    /// For now, this only supports NixOS configurations via `nh os repl`
     Repl(CommonReplArgs),
 
     /// Show an overview of the system's info

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -74,33 +74,55 @@ pub enum NHCommand {
     Completions(CompletionArgs),
 }
 
+#[derive(Debug, Args)]
+pub struct CommonReplArgs {
+    /// Flake reference to build
+    #[arg(env = "FLAKE", value_hint = clap::ValueHint::DirPath)]
+    pub flakeref: FlakeRef,
+
+    /// Output to choose from the flakeref. Hostname is used by default
+    #[arg(long, short = 'H', global = true)]
+    pub hostname: Option<OsString>,
+
+    /// Extra arguments passed verbatim to nix repl.
+    #[arg(last = true)]
+    pub extra_args: Vec<String>,
+}
+
 #[derive(Args, Debug)]
 #[clap(verbatim_doc_comment)]
 /// NixOS functionality
 ///
-/// Reimplementations of nixos-rebuild
+/// Implements mostly around but not exclusively nixos-rebuild
 pub struct OsArgs {
     #[command(subcommand)]
-    pub action: OsRebuildType,
+    pub action: OsCommandType,
 }
 
 #[derive(Debug, Subcommand)]
-pub enum OsRebuildType {
+pub enum OsCommandType {
     /// Build and activate the new configuration, and make it the boot default
-    Switch(OsRebuildArgs),
+    Switch(OsSubcommandArgs),
+
     /// Build the new configuration and make it the boot default
-    Boot(OsRebuildArgs),
+    Boot(OsSubcommandArgs),
+
     /// Build and activate the new configuration
-    Test(OsRebuildArgs),
+    Test(OsSubcommandArgs),
+
     /// Build the new configuration
-    Build(OsRebuildArgs),
+    Build(OsSubcommandArgs),
+
+    /// Enter a Nix REPL with the target
+    Repl(CommonReplArgs),
+
     /// Show an overview of the system's info
     #[command(hide = true)]
     Info,
 }
 
 #[derive(Debug, Args)]
-pub struct OsRebuildArgs {
+pub struct OsSubcommandArgs {
     #[command(flatten)]
     pub common: CommonRebuildArgs,
 
@@ -160,7 +182,7 @@ pub struct CommonRebuildArgs {
 
     /// Path to save the result link. Defaults to using a temporary directory.
     #[arg(long, short)]
-    pub out_link: Option<PathBuf>
+    pub out_link: Option<PathBuf>,
 }
 
 #[derive(Args, Debug)]

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -1,5 +1,5 @@
 use std::ops::Deref;
-use std::{env, vec};
+use std::vec;
 
 use color_eyre::eyre::{bail, Context};
 use color_eyre::Result;
@@ -7,8 +7,8 @@ use color_eyre::Result;
 use tracing::{debug, info, warn};
 
 use crate::interface::NHRunnable;
-use crate::interface::OsRebuildType::{self, Boot, Build, Switch, Test};
-use crate::interface::{self, OsRebuildArgs};
+use crate::interface::OsCommandType::{self, Boot, Build, Repl, Switch, Test};
+use crate::interface::{self, CommonReplArgs, OsSubcommandArgs};
 use crate::util::{compare_semver, get_nix_version};
 use crate::*;
 
@@ -21,13 +21,47 @@ impl NHRunnable for interface::OsArgs {
     fn run(&self) -> Result<()> {
         match &self.action {
             Switch(args) | Boot(args) | Test(args) | Build(args) => args.rebuild(&self.action),
+            Repl(args) => args.repl(),
             s => bail!("Subcommand {:?} not yet implemented", s),
         }
     }
 }
 
-impl OsRebuildArgs {
-    pub fn rebuild(&self, rebuild_type: &OsRebuildType) -> Result<()> {
+impl CommonReplArgs {
+    pub fn repl(&self) -> Result<()> {
+        let mut repl_command = vec!["nix", "repl"];
+
+        let flakeref = format!(
+            "{}#nixosConfigurations.{}",
+            self.flakeref.as_str(),
+            hostname::get()
+                .context("Failed to get hostname")?
+                .to_string_lossy()
+        );
+
+        repl_command.push(&flakeref);
+
+        if !&self.extra_args.is_empty() {
+            for arg in &self.extra_args {
+                repl_command.push(arg);
+            }
+        };
+
+        debug!("repl_command: {:?}", repl_command);
+
+        commands::CommandBuilder::default()
+            .args(repl_command)
+            .message("Entering Nix REPL")
+            .build()?
+            .exec()
+            .unwrap();
+
+        Ok(())
+    }
+}
+
+impl OsSubcommandArgs {
+    pub fn rebuild(&self, rebuild_type: &OsCommandType) -> Result<()> {
         let use_sudo = if self.bypass_root_check {
             warn!("Bypassing root check, now running nix as root");
             false
@@ -125,7 +159,7 @@ impl OsRebuildArgs {
             .build()?
             .exec()?;
 
-        if self.common.dry || matches!(rebuild_type, OsRebuildType::Build(_)) {
+        if self.common.dry || matches!(rebuild_type, OsCommandType::Build(_)) {
             return Ok(());
         }
 


### PR DESCRIPTION
Adds a repl subcommand for `nh os` which puts the user into a repl with the active nixosConfiguration loaded. Equivalent of `nix repl .#nixosConfiguration.$HOSTNAME` or entering nix repl and running `:lf nixosConfigurations.<hostname>`.

Things to maybe do:
1. Implement `nh home repl` (I really don't want to)
2. Fall back to a nix repl with `nixosConfigurations` if hostname cannot be get